### PR TITLE
JAWS 2018 & 2019 test results

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,24 +158,24 @@
             </tr>
             <tr>
               <td>Win/Edge/JAWS</td>
-              <td>TBD</td>
-              <td>TBD</td>
-              <td>TBD</td>
-              <td>TBD</td>
+              <td><span class="fail">Fail</span></td>
+              <td><span class="pass">Pass</span></td>
+              <td><span class="pass">Pass</span></td>
+              <td><span class="pass">Pass</span></td>
             </tr>
             <tr>
               <td>Win/Chrome/JAWS</td>
-              <td>TBD</td>
-              <td>TBD</td>
-              <td>TBD</td>
-              <td>TBD</td>
+              <td><span class="fail">Fail</span></td>
+              <td><span class="pass">Pass</span></td>
+              <td><span class="pass">Pass</span></td>
+              <td><span class="pass">Pass</span></td>
             </tr>
             <tr>
               <td>Win/Firefox/JAWS</td>
-              <td>TBD</td>
-              <td>TBD</td>
-              <td>TBD</td>
-              <td>TBD</td>
+              <td><span class="fail">Fail</span></td>
+              <td><span class="pass">Pass</span></td>
+              <td><span class="pass">Pass</span></td>
+              <td><span class="pass">Pass</span></td>
             </tr>
             <tr>
               <td>OSX/Chrome/Voiceover</td>


### PR DESCRIPTION
Closes #1 

Tested with latest builds of JAWS 2018 and 2019 and latest public releases of Edge (pre-chromium), Chrome and Firefox.

Proper accessible names were announced when:
* navigating from the heading to the input by virtual cursor (down arrow).
* navigating by form control hot key <kbd>F</kbd>.
* navigating by <kbd>TAB</kbd> key.

Reviewing the listing of form controls element dialog, the following was listed:
>Example 1: No label Edit
>Example 2 Edit
>Example 3 Edit
>Example 4 Edit